### PR TITLE
Fix KVStore updates at capacity

### DIFF
--- a/src/main/java/com/springbootkvstore/lol/KVStore.java
+++ b/src/main/java/com/springbootkvstore/lol/KVStore.java
@@ -25,7 +25,8 @@ public class KVStore<K, V> {
     }
 
     public boolean add(K key, V val) {
-        if (map.size() >= maxSize) {
+        // allow updates to existing keys even when the store reached its max size
+        if (!map.containsKey(key) && map.size() >= maxSize) {
             return false;
         }
         map.put(key, val);

--- a/src/test/java/com/springbootkvstore/lol/KVStoreTest.java
+++ b/src/test/java/com/springbootkvstore/lol/KVStoreTest.java
@@ -36,4 +36,13 @@ class KVStoreTest {
         assertEquals("value", kvStore.get("key"));
         assertNull(kvStore.get("key1"));
     }
+
+    @Test
+    void testUpdateWhenFull(){
+        kvStore = new KVStore<>(1);
+        assertTrue(kvStore.add("key", "value"));
+        // store is full now but updating existing key should still succeed
+        assertTrue(kvStore.add("key", "newValue"));
+        assertEquals("newValue", kvStore.get("key"));
+    }
 }

--- a/src/test/java/com/springbootkvstore/lol/SpringBootInMemoryTest.java
+++ b/src/test/java/com/springbootkvstore/lol/SpringBootInMemoryTest.java
@@ -67,6 +67,26 @@ class SpringBootInMemoryTest {
                 .andExpect(MockMvcResultMatchers.status().is4xxClientError());
     }
 
+    @Test
+    void testUpdateExistingWhenFull() throws Exception {
+        IntStream.range(1, 1001).forEach(i -> {
+            try {
+                performAdd(String.valueOf(i), String.valueOf(i));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        performAdd("500", "new")
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string("Success"));
+
+        mvc.perform(MockMvcRequestBuilders.get("/get")
+                        .param("key", "500"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string("new"));
+    }
+
     private ResultActions performAdd(String key, String value) throws Exception {
         return mvc.perform(MockMvcRequestBuilders.get("/set")
                 .param("key", key)


### PR DESCRIPTION
## Summary
- allow updates of existing keys when the KVStore has reached its size limit
- add regression tests for the update scenario in `KVStore` and controller tests

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683fd51e5e3483329e76029c00b6f67a