### PR TITLE
Fix race in KVStore.add

### DIFF
--- a/src/main/java/com/springbootkvstore/lol/KVStore.java
+++ b/src/main/java/com/springbootkvstore/lol/KVStore.java
@@ -24,10 +24,16 @@ public class KVStore<K, V> {
         return map.get(key);
     }
 
-    public boolean add(K key, V val) {
+    public synchronized boolean add(K key, V val) {
+        if (map.containsKey(key)) {
+            map.put(key, val);
+            return true;
+        }
+
         if (map.size() >= maxSize) {
             return false;
         }
+
         map.put(key, val);
         return true;
     }

--- a/src/test/java/com/springbootkvstore/lol/KVStoreTest.java
+++ b/src/test/java/com/springbootkvstore/lol/KVStoreTest.java
@@ -36,4 +36,22 @@ class KVStoreTest {
         assertEquals("value", kvStore.get("key"));
         assertNull(kvStore.get("key1"));
     }
+
+    @Test
+    void testConcurrentAddRespectMaxSize() throws InterruptedException {
+        kvStore = new KVStore<>(1);
+
+        Runnable addTask = () -> kvStore.add("key1", "value1");
+
+        Thread t1 = new Thread(addTask);
+        Thread t2 = new Thread(addTask);
+
+        t1.start();
+        t2.start();
+
+        t1.join();
+        t2.join();
+
+        assertEquals(1, kvStore.all().size());
+    }
 }


### PR DESCRIPTION
## Summary
- avoid race conditions when adding entries to KVStore
- add regression test covering concurrent insertion

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683fd4abfd308332b70b0ddda40c567b