### PR TITLE
Add delete endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Todo:
 /set?key=key&val=val
 /get?key-key
 /get-all
+/delete?key=key
 </code>
 
 ### Why?

--- a/src/main/java/com/springbootkvstore/lol/KVStore.java
+++ b/src/main/java/com/springbootkvstore/lol/KVStore.java
@@ -44,6 +44,16 @@ public class KVStore<K, V> {
         return true;
     }
 
+    public synchronized boolean delete(K key) {
+        if (map.containsKey(key)) {
+            map.remove(key);
+            log.debug("Deleted key {}", key);
+            return true;
+        }
+        log.warn("Key {} not found for deletion", key);
+        return false;
+    }
+
     public Collection<String> all() {
         return map.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.toList());
     }

--- a/src/main/java/com/springbootkvstore/lol/SpringBootInMemory.java
+++ b/src/main/java/com/springbootkvstore/lol/SpringBootInMemory.java
@@ -70,5 +70,21 @@ public class SpringBootInMemory {
                 HttpStatus.OK);
     }
 
+    @PostMapping("/delete")
+    public ResponseEntity<String> delete(@RequestParam String key) {
+        if (StringUtils.isAnyNullOrBlank(key)) {
+            log.warn("/delete called with invalid key='{}'", key);
+            return ResponseEntity.badRequest().build();
+        }
+
+        if (kvStore.delete(key)) {
+            log.info("Deleted key {}", key);
+            return new ResponseEntity<>("Success", HttpStatus.OK);
+        } else {
+            log.warn("Key {} not found for delete", key);
+            return new ResponseEntity<>("Key not found", HttpStatus.NOT_FOUND);
+        }
+    }
+
 
 }

--- a/src/test/java/com/springbootkvstore/lol/KVStoreTest.java
+++ b/src/test/java/com/springbootkvstore/lol/KVStoreTest.java
@@ -52,6 +52,14 @@ class KVStoreTest {
     }
 
     @Test
+    void testDelete() {
+        kvStore.add("key", "value");
+        assertTrue(kvStore.delete("key"));
+        assertNull(kvStore.get("key"));
+        assertFalse(kvStore.delete("missing"));
+    }
+
+    @Test
     void testConcurrentAddDoesNotExceedMaxSize() throws InterruptedException {
         int max = 50;
         kvStore = new KVStore<>(max);

--- a/src/test/java/com/springbootkvstore/lol/SpringBootInMemoryTest.java
+++ b/src/test/java/com/springbootkvstore/lol/SpringBootInMemoryTest.java
@@ -87,9 +87,27 @@ class SpringBootInMemoryTest {
                 .andExpect(MockMvcResultMatchers.content().string("new"));
     }
 
+    @Test
+    void testDelete() throws Exception {
+        performAdd("key", "value")
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        performDelete("key")
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string("Success"));
+
+        performDelete("missing")
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
     private ResultActions performAdd(String key, String value) throws Exception {
         return mvc.perform(MockMvcRequestBuilders.post("/set")
                 .param("key", key)
                 .param("val", value));
+    }
+
+    private ResultActions performDelete(String key) throws Exception {
+        return mvc.perform(MockMvcRequestBuilders.post("/delete")
+                .param("key", key));
     }
 }


### PR DESCRIPTION
## Summary
- allow removing key/value pairs from KV store
- expose `/delete` HTTP endpoint for deletion
- test new functionality in unit and integration tests
- document the delete endpoint in README

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68402a5ec6a48332a237db072a8c868d