### PR TITLE
Add simple HTML view for KV store

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,10 +18,11 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+        developmentOnly 'org.springframework.boot:spring-boot-devtools'
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/springbootkvstore/lol/KVStore.java
+++ b/src/main/java/com/springbootkvstore/lol/KVStore.java
@@ -58,6 +58,10 @@ public class KVStore<K, V> {
         return map.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.toList());
     }
 
+    public Map<K, V> asMap() {
+        return Map.copyOf(map);
+    }
+
     @Override
     public String toString() {
         return String.join(", ", this.all());

--- a/src/main/java/com/springbootkvstore/lol/SpringBootInMemory.java
+++ b/src/main/java/com/springbootkvstore/lol/SpringBootInMemory.java
@@ -5,17 +5,19 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 
 @SpringBootApplication
-@RestController
+@Controller
 public class SpringBootInMemory {
 
     private static final Logger log = LoggerFactory.getLogger(SpringBootInMemory.class);
@@ -29,6 +31,7 @@ public class SpringBootInMemory {
     private KVStore<String, String> kvStore;
 
     @PostMapping("/set")
+    @ResponseBody
     public ResponseEntity<String> set(@RequestParam String key, @RequestParam String val) {
         if (StringUtils.isAnyNullOrBlank(key, val)) {
             log.warn("/set called with invalid parameters key='{}' val='{}'", key, val);
@@ -48,6 +51,7 @@ public class SpringBootInMemory {
     }
 
     @GetMapping("/get")
+    @ResponseBody
     public ResponseEntity<String> get(@RequestParam String key) {
         if (key == null) {
             log.warn("/get called with null key");
@@ -62,6 +66,7 @@ public class SpringBootInMemory {
     }
 
     @GetMapping("/get-all")
+    @ResponseBody
     public ResponseEntity<String> getAll() {
         Collection<String> all = kvStore.all();
         log.info("Returning all entries, count={}", all.size());
@@ -70,7 +75,14 @@ public class SpringBootInMemory {
                 HttpStatus.OK);
     }
 
+    @GetMapping("/view")
+    public String view(Model model) {
+        model.addAttribute("entries", kvStore.asMap());
+        return "view";
+    }
+
     @PostMapping("/delete")
+    @ResponseBody
     public ResponseEntity<String> delete(@RequestParam String key) {
         if (StringUtils.isAnyNullOrBlank(key)) {
             log.warn("/delete called with invalid key='{}'", key);

--- a/src/main/resources/templates/view.html
+++ b/src/main/resources/templates/view.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>KV Store</title>
+</head>
+<body>
+<h1>Key Value Pairs</h1>
+<table>
+    <tr><th>Key</th><th>Value</th></tr>
+    <tr th:each="entry : ${entries.entrySet()}">
+        <td th:text="${entry.key}"></td>
+        <td th:text="${entry.value}"></td>
+    </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Thymeleaf dependency
- expose map view via `/view` endpoint
- provide `asMap()` method in `KVStore`
- create template to list key-value pairs
- adjust controller annotations

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68402b7ad9688332bc0e74c799dffd4c