### PR TITLE
Async persistence

### DIFF
--- a/src/test/java/com/springbootkvstore/lol/KVStorePersistenceTest.java
+++ b/src/test/java/com/springbootkvstore/lol/KVStorePersistenceTest.java
@@ -18,12 +18,14 @@ class KVStorePersistenceTest {
         KVStore<String, String> kv = new KVStore<>(10, file.toString());
         kv.add("a", "b");
         kv.add("c", "d");
+        kv.flush();
 
         KVStore<String, String> kv2 = new KVStore<>(10, file.toString());
         assertEquals("b", kv2.get("a"));
         assertEquals("d", kv2.get("c"));
 
         kv2.delete("a");
+        kv2.flush();
 
         KVStore<String, String> kv3 = new KVStore<>(10, file.toString());
         assertNull(kv3.get("a"));


### PR DESCRIPTION
## Summary
- update KVStore to persist changes on a background thread
- add `flush()` helper for tests
- update persistence test to flush before reloading

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68403b71a4f8833285b9ebc0d1d5c456